### PR TITLE
Add JWT auth skeleton

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,10 +23,18 @@
     "@nestjs/common": "^10.0.0",
     "@nestjs/core": "^10.0.0",
     "@nestjs/platform-express": "^10.0.0",
+    "@nestjs/jwt": "^10.0.0",
+    "@nestjs/passport": "^10.0.0",
+    "@nestjs/swagger": "^7.2.0",
+    "passport": "^0.7.0",
+    "passport-jwt": "^4.0.1",
+    "@prisma/client": "^5.14.2",
+    "bcrypt": "^5.1.1",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },
   "devDependencies": {
+    "prisma": "^5.14.2",
     "@nestjs/cli": "^10.0.0",
     "@nestjs/schematics": "^10.0.0",
     "@nestjs/testing": "^10.0.0",

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -1,0 +1,24 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "sqlite"
+  url      = "file:./dev.db"
+}
+
+model User {
+  id        Int       @id @default(autoincrement())
+  email     String    @unique
+  password  String
+  sessions  Session[]
+}
+
+model Session {
+  id           Int      @id @default(autoincrement())
+  user         User     @relation(fields: [userId], references: [id])
+  userId       Int
+  refreshToken String    @unique
+  createdAt    DateTime @default(now())
+  revokedAt    DateTime?
+}

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -1,4 +1,5 @@
-import { Controller, Get } from '@nestjs/common';
+import { Controller, Get, UseGuards, Req } from '@nestjs/common';
+import { JwtAuthGuard } from './auth/jwt-auth.guard';
 import { AppService } from './app.service';
 
 @Controller()
@@ -8,5 +9,11 @@ export class AppController {
   @Get()
   getHello(): string {
     return this.appService.getHello();
+  }
+
+  @UseGuards(JwtAuthGuard)
+  @Get('profile')
+  getProfile(@Req() req: any) {
+    return req.user;
   }
 }

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
+import { AuthModule } from './auth/auth.module';
+import { PrismaModule } from './prisma/prisma.module';
 
 @Module({
-  imports: [],
+  imports: [AuthModule, PrismaModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,0 +1,24 @@
+import { Body, Controller, Post } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { AuthService } from './auth.service';
+
+@ApiTags('auth')
+@Controller('auth')
+export class AuthController {
+  constructor(private auth: AuthService) {}
+
+  @Post('register')
+  register(@Body() body: { email: string; password: string }) {
+    return this.auth.register(body.email, body.password);
+  }
+
+  @Post('login')
+  login(@Body() body: { email: string; password: string }) {
+    return this.auth.login(body.email, body.password);
+  }
+
+  @Post('refresh')
+  refresh(@Body('refreshToken') refreshToken: string) {
+    return this.auth.refresh(refreshToken);
+  }
+}

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,0 +1,23 @@
+import { Module } from '@nestjs/common';
+import { JwtModule } from '@nestjs/jwt';
+import { PassportModule } from '@nestjs/passport';
+import { UserModule } from '../user/user.module';
+import { PrismaModule } from '../prisma/prisma.module';
+import { AuthService } from './auth.service';
+import { AuthController } from './auth.controller';
+import { JwtStrategy } from './jwt.strategy';
+
+@Module({
+  imports: [
+    UserModule,
+    PrismaModule,
+    PassportModule,
+    JwtModule.register({
+      secret: process.env.JWT_SECRET || 'secret',
+      signOptions: { expiresIn: '15m' },
+    }),
+  ],
+  providers: [AuthService, JwtStrategy],
+  controllers: [AuthController],
+})
+export class AuthModule {}

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -1,0 +1,48 @@
+import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { JwtService } from '@nestjs/jwt';
+import { PrismaService } from '../prisma/prisma.service';
+import { UserService } from '../user/user.service';
+
+@Injectable()
+export class AuthService {
+  constructor(
+    private users: UserService,
+    private jwt: JwtService,
+    private prisma: PrismaService,
+  ) {}
+
+  async register(email: string, password: string) {
+    const user = await this.users.create(email, password);
+    return this.generateTokens(user.id);
+  }
+
+  async login(email: string, password: string) {
+    const user = await this.users.validateUser(email, password);
+    if (!user) throw new UnauthorizedException();
+    return this.generateTokens(user.id);
+  }
+
+  async refresh(refreshToken: string) {
+    const session = await this.prisma.session.findUnique({
+      where: { refreshToken },
+    });
+    if (!session || session.revokedAt) throw new UnauthorizedException();
+    return this.generateTokens(session.userId, session);
+  }
+
+  private async generateTokens(userId: number, session?: { id: number }) {
+    const accessToken = await this.jwt.signAsync({ sub: userId });
+    const refreshToken = Math.random().toString(36).slice(2);
+    if (session) {
+      await this.prisma.session.update({
+        where: { id: session.id },
+        data: { refreshToken },
+      });
+    } else {
+      await this.prisma.session.create({
+        data: { userId, refreshToken },
+      });
+    }
+    return { accessToken, refreshToken };
+  }
+}

--- a/src/auth/jwt-auth.guard.ts
+++ b/src/auth/jwt-auth.guard.ts
@@ -1,0 +1,3 @@
+import { AuthGuard } from '@nestjs/passport';
+
+export class JwtAuthGuard extends AuthGuard('jwt') {}

--- a/src/auth/jwt.strategy.ts
+++ b/src/auth/jwt.strategy.ts
@@ -1,0 +1,17 @@
+import { Injectable } from '@nestjs/common';
+import { PassportStrategy } from '@nestjs/passport';
+import { ExtractJwt, Strategy } from 'passport-jwt';
+
+@Injectable()
+export class JwtStrategy extends PassportStrategy(Strategy) {
+  constructor() {
+    super({
+      jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+      secretOrKey: process.env.JWT_SECRET || 'secret',
+    });
+  }
+
+  async validate(payload: any) {
+    return { userId: payload.sub };
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,15 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+  const config = new DocumentBuilder()
+    .setTitle('Auth API')
+    .setVersion('1.0')
+    .build();
+  const document = SwaggerModule.createDocument(app, config);
+  SwaggerModule.setup('api', app, document);
   await app.listen(process.env.PORT ?? 3000);
 }
 bootstrap();

--- a/src/prisma/prisma.module.ts
+++ b/src/prisma/prisma.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from './prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class PrismaModule {}

--- a/src/prisma/prisma.service.ts
+++ b/src/prisma/prisma.service.ts
@@ -1,0 +1,15 @@
+import { INestApplication, Injectable, OnModuleInit } from '@nestjs/common';
+import { PrismaClient } from '@prisma/client';
+
+@Injectable()
+export class PrismaService extends PrismaClient implements OnModuleInit {
+  async onModuleInit() {
+    await this.$connect();
+  }
+
+  async enableShutdownHooks(app: INestApplication) {
+    this.$on('beforeExit', async () => {
+      await app.close();
+    });
+  }
+}

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -1,0 +1,8 @@
+import { Module } from '@nestjs/common';
+import { UserService } from './user.service';
+
+@Module({
+  providers: [UserService],
+  exports: [UserService],
+})
+export class UserModule {}

--- a/src/user/user.service.ts
+++ b/src/user/user.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+import * as bcrypt from 'bcrypt';
+
+@Injectable()
+export class UserService {
+  constructor(private prisma: PrismaService) {}
+
+  async create(email: string, password: string) {
+    const hash = await bcrypt.hash(password, 10);
+    return this.prisma.user.create({
+      data: { email, password: hash },
+    });
+  }
+
+  async findByEmail(email: string) {
+    return this.prisma.user.findUnique({ where: { email } });
+  }
+
+  async validateUser(email: string, password: string) {
+    const user = await this.findByEmail(email);
+    if (!user) return null;
+    const valid = await bcrypt.compare(password, user.password);
+    if (!valid) return null;
+    return user;
+  }
+}


### PR DESCRIPTION
## Summary
- install jwt, passport, prisma dependencies
- setup Prisma schema and service
- add user and auth modules with register/login/refresh endpoints
- wire up JWT strategy and guard
- expose Swagger docs

## Testing
- `npm run test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e9050436483289713f04a94daf5e2