### PR TITLE
Add setup and db modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "passport-jwt": "^4.0.1",
     "@prisma/client": "^5.14.2",
     "bcrypt": "^5.1.1",
+    "otostogan-nest-logger": "^1.0.0",
     "reflect-metadata": "^0.2.0",
     "rxjs": "^7.8.1"
   },

--- a/src/app.controller.ts
+++ b/src/app.controller.ts
@@ -4,11 +4,11 @@ import { AppService } from './app.service';
 
 @Controller()
 export class AppController {
-  constructor(private readonly appService: AppService) {}
+  constructor(private readonly _appService: AppService) {}
 
   @Get()
   getHello(): string {
-    return this.appService.getHello();
+    return this._appService.getHello();
   }
 
   @UseGuards(JwtAuthGuard)

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -2,10 +2,10 @@ import { Module } from '@nestjs/common';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { AuthModule } from './auth/auth.module';
-import { PrismaModule } from './prisma/prisma.module';
+import { SetupModule } from './setup/setup.module';
 
 @Module({
-  imports: [AuthModule, PrismaModule],
+  imports: [SetupModule, AuthModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -1,24 +1,28 @@
 import { Body, Controller, Post } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { ApiTags, ApiResponse } from '@nestjs/swagger';
 import { AuthService } from './auth.service';
+import { Auth as AuthDto } from './dto';
 
 @ApiTags('auth')
 @Controller('auth')
 export class AuthController {
-  constructor(private auth: AuthService) {}
+  constructor(private _auth: AuthService) {}
 
   @Post('register')
-  register(@Body() body: { email: string; password: string }) {
-    return this.auth.register(body.email, body.password);
+  @ApiResponse({ status: 201, type: AuthDto.TokensDto })
+  register(@Body() body: AuthDto.RegisterDto) {
+    return this._auth.register(body.email, body.password);
   }
 
   @Post('login')
-  login(@Body() body: { email: string; password: string }) {
-    return this.auth.login(body.email, body.password);
+  @ApiResponse({ status: 200, type: AuthDto.TokensDto })
+  login(@Body() body: AuthDto.LoginDto) {
+    return this._auth.login(body.email, body.password);
   }
 
   @Post('refresh')
-  refresh(@Body('refreshToken') refreshToken: string) {
-    return this.auth.refresh(refreshToken);
+  @ApiResponse({ status: 200, type: AuthDto.TokensDto })
+  refresh(@Body() body: AuthDto.RefreshDto) {
+    return this._auth.refresh(body.refreshToken);
   }
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -2,7 +2,7 @@ import { Module } from '@nestjs/common';
 import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { UserModule } from '../user/user.module';
-import { PrismaModule } from '../prisma/prisma.module';
+import { DbModule } from '../db/db.module';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
 import { JwtStrategy } from './jwt.strategy';
@@ -10,7 +10,7 @@ import { JwtStrategy } from './jwt.strategy';
 @Module({
   imports: [
     UserModule,
-    PrismaModule,
+    DbModule,
     PassportModule,
     JwtModule.register({
       secret: process.env.JWT_SECRET || 'secret',

--- a/src/auth/dto.ts
+++ b/src/auth/dto.ts
@@ -1,0 +1,46 @@
+import { ApiProperty, ApiSchema } from '@nestjs/swagger';
+import { IsEmail, IsString, MinLength } from 'class-validator';
+
+export namespace Auth {
+  @ApiSchema({ name: 'RegisterDto' })
+  export class RegisterDto {
+    @ApiProperty()
+    @IsEmail()
+    email: string;
+
+    @ApiProperty()
+    @IsString()
+    @MinLength(6)
+    password: string;
+  }
+
+  @ApiSchema({ name: 'LoginDto' })
+  export class LoginDto {
+    @ApiProperty()
+    @IsEmail()
+    email: string;
+
+    @ApiProperty()
+    @IsString()
+    @MinLength(6)
+    password: string;
+  }
+
+  @ApiSchema({ name: 'RefreshDto' })
+  export class RefreshDto {
+    @ApiProperty()
+    @IsString()
+    refreshToken: string;
+  }
+
+  @ApiSchema({ name: 'TokensDto' })
+  export class TokensDto {
+    @ApiProperty()
+    @IsString()
+    accessToken: string;
+
+    @ApiProperty()
+    @IsString()
+    refreshToken: string;
+  }
+}

--- a/src/db/db.module.ts
+++ b/src/db/db.module.ts
@@ -1,0 +1,10 @@
+import { Global, Module } from '@nestjs/common';
+import { PrismaService } from '../prisma/prisma.service';
+
+@Global()
+@Module({
+  providers: [PrismaService],
+  exports: [PrismaService],
+})
+export class DbModule {}
+

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,9 +1,12 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { Logger } from 'otostogan-nest-logger';
 
 async function bootstrap() {
-  const app = await NestFactory.create(AppModule);
+  const app = await NestFactory.create(AppModule, { bufferLogs: true });
+  const logger = app.get(Logger);
+  app.useLogger(logger);
   const config = new DocumentBuilder()
     .setTitle('Auth API')
     .setVersion('1.0')

--- a/src/setup/setup.module.ts
+++ b/src/setup/setup.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { LoggerModule } from 'otostogan-nest-logger';
+
+@Module({
+  imports: [ConfigModule.forRoot({ isGlobal: true }), LoggerModule.forRoot()],
+})
+export class SetupModule {}
+
+


### PR DESCRIPTION
## Summary
- create global DB module
- configure SetupModule with Config and logger
- import SetupModule and use DbModule in AuthModule
- rename injected services to use underscore prefix
- declare otostogan-nest-logger dependency
- connect otostogan-nest-logger in SetupModule and bootstrap

## Testing
- `npm run lint` *(fails: ESLint couldn't find config)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e91d910408328ad19d20955bb2008